### PR TITLE
Support for / character in config.name

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ function start() {
         } else if (!isNaN(payload)) {
             payload = parseFloat(payload);
         }
-        const [, method, type, name, datapoint] = topic.split('/');
+        const [, method, type, name, datapoint] = topic.substr(config.name.length).split('/');
 
         switch (method) {
             case 'set':


### PR DESCRIPTION
This addresses #8 by skipping the first n characters on an incoming message before splitting on the `/`

```
my/topic/prefix (prefix)
my/topic/prefix/method/type/name/datapoint (example message)
               /method/type/name/datapoint (remove prefix)
[, method, type, name, datapoint] = '/method/type/name/datapoint'.split('/');
['', 'method', 'type', 'name', 'datapoint']
```